### PR TITLE
proposal for #42 provide a custom object to the callback

### DIFF
--- a/util/toaudio5.js
+++ b/util/toaudio5.js
@@ -49,6 +49,7 @@
 //		[3]: MIDI note pitch (with cents)
 //		[4]: duration
 //		[5]: volume (0..1 - optional)
+//		[6]: custom object to be passed to the onnote - optional
 //
 // stop() - stop playing
 //
@@ -423,8 +424,8 @@ function Audio5(i_conf) {
 			if (follow) {
 			    var	i = e[0];
 				st = (st - ac.currentTime) * 1000;
-				setTimeout(onnote, st, i, true);
-				setTimeout(onnote, st + d * 1000, i, false)
+				setTimeout(onnote, st, i, true, e[6]);
+				setTimeout(onnote, st + d * 1000, i, false, e[6])
 			}
 
 			e = a_e[++evt_idx]


### PR DESCRIPTION
I have added support for a custom object to be passed to onnote. This allowed me to recreate the intended highlighting while playing notes.

I also tried to implement this in play.js / gen_notes. But I could not make it work with ties and rests.
I also did not want to propose too many changes for play.js. So when playing the abc model from zupfnoter it still highlights only one note but no rests and no ties.

Please feel free for any other solution for the custom object. I tried to support the custom object in an extra array, but this did not work properly and was much effort. So I would appreciate if you could provide this.