### PR TITLE
save abc-text upon change; restore upon start

### DIFF
--- a/edit-de.js
+++ b/edit-de.js
@@ -25,8 +25,9 @@ function loadtxt() {
 		pr: 'Einstellungen',
 		saveas: 'Speichere File',
 		sful: 'Sound font URL',
-		sp: 'Speed'
-	}
+		sp: 'Speed',
+    kls: 'abc im localstore halten'
+  }
 
 	for (var k in text_kv)
 		document.getElementById(k).innerHTML = text_kv[k];

--- a/edit-en.js
+++ b/edit-en.js
@@ -25,7 +25,8 @@ function loadtxt() {
 		pr: 'Preferences',
 		saveas: 'Save file',
 		sful: 'Soundfont URL',
-		sp: 'Speed'
+		sp: 'Speed',
+		kls: 'keep abc in localstorage'
 	}
 
 	for (var k in text_kv)

--- a/editor/edit.js
+++ b/editor/edit.js
@@ -616,6 +616,13 @@ function edit_init() {
 		document.head.appendChild(s)
 	}
 
+	function set_abc(){
+    var v = storage(true, 'abc-source');
+    if (v) {
+      elt_ref.source.value = v;
+    }
+  }
+
 	function set_pref() {
 	    var	v = storage(true, "fontsz")
 		if (v) {
@@ -686,6 +693,7 @@ function edit_init() {
 		});
 	}
 	set_pref()	// set the preferences from local storage
+	set_abc()   // load abc from local storage
 }
 
 // drag and drop
@@ -719,6 +727,7 @@ function dropped(evt) {
 // render the music after 2 seconds on textarea change
 var timer
 function src_change() {
+	storage(true, 'abc-source', elt_ref.source.value);
 	clearTimeout(timer);
 	if (!playing)
 		timer = setTimeout(render, 2000)

--- a/editor/edit.js
+++ b/editor/edit.js
@@ -491,6 +491,19 @@ function destroyClickedElement(evt) {
 	document.body.removeChild(evt.target)
 }
 
+// handle saving to localstoreage
+
+function set_keep_in_localstorage(e){
+	if (e.checked) {
+    storage(true, 'keep-abc-source', true);
+	}
+	else
+	{
+    storage(true, 'keep-abc-source', 0);
+    storage(true, 'abc-source', 0);
+	}
+}
+
 // set the size of the font of the textarea
 function setfont() {
     var	fs = document.getElementById("fontsize").value.toString();
@@ -682,7 +695,8 @@ function edit_init() {
 				document.getElementById("playdiv4").style.display =
 					"list-item";
 
-			document.getElementById("fol").checked = abcplay.set_follow();
+      document.getElementById("fol").checked = abcplay.set_follow();
+      document.getElementById("klsl").checked = storage(true, 'keep-abc-source')
 			document.getElementById("sfu").value = abcplay.set_sfu();
 //			document.getElementById("spv").innerHTML =
 //				Math.log(abcplay.set_speed()) / Math.log(3);
@@ -727,7 +741,9 @@ function dropped(evt) {
 // render the music after 2 seconds on textarea change
 var timer
 function src_change() {
-	storage(true, 'abc-source', elt_ref.source.value);
+	if (storage(true, 'keep-abc-source')){
+    storage(true, 'abc-source', elt_ref.source.value);
+  }
 	clearTimeout(timer);
 	if (!playing)
 		timer = setTimeout(render, 2000)

--- a/editor/edit.xhtml
+++ b/editor/edit.xhtml
@@ -55,6 +55,11 @@
 					onchange="set_speed(this.value)"/>
 				<label id="spvl">1</label>
 			</li>
+			<li id="playdiv5" style="display: block">
+				<label id="kls">keep in localstorage</label>
+				<input id="klsl" type="checkbox" checked="false"
+					   onclick="set_keep_in_localstorage(this)"/>
+			</li>
 		</ul>
 	</li>
 	<li class="dropbutton"><label id="lg">Language</label>


### PR DESCRIPTION
While testing with edit-1.xhtml, whenever i reload the page (e.g. due to a switch to another commit) i have to reenter the abc code.

I therefore added a feature that edit-1.xhtml restores the latest abc-text upon reload. This also helps, if the user occasionally has left the page in the browser, or restarts after a crash.

Would be glad if you could merge this. Maybe it makes sense to add a preference which toggles this feature.

